### PR TITLE
Depend on Rack >= 1

### DIFF
--- a/rack-traffic-logger.gemspec
+++ b/rack-traffic-logger.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rack', '>= 1'
 
-  spec.required_ruby_version = '~> 2.1'
+  spec.required_ruby_version = '=> 2.1'
 end

--- a/rack-traffic-logger.gemspec
+++ b/rack-traffic-logger.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rack', '~> 1'
+  spec.add_dependency 'rack', '>= 1'
 
   spec.required_ruby_version = '~> 2.1'
 end


### PR DESCRIPTION
To work with Rack 2.0+

By relaxing the version requirement I can include this into my Rails 5.1 app and it works just great.